### PR TITLE
Ajusta o select de atributo do Customer na configuração "Federal tax payer id"

### DIFF
--- a/Model/Config/Source/CustomerAttribute.php
+++ b/Model/Config/Source/CustomerAttribute.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Intelipost. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Intelipost\Push\Model\Config\Source;
+
+use Magento\Customer\Api\CustomerMetadataInterface;
+use Magento\Eav\Model\ResourceModel\Entity\Attribute\CollectionFactory;
+use Magento\Framework\Data\OptionSourceInterface;
+
+class CustomerAttribute implements OptionSourceInterface
+{
+    const CUSTOMER_EAV_ENTITY_TYPE_ID = 1;
+
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * @param CollectionFactory $collectionFactory
+     */
+    public function __construct(CollectionFactory $collectionFactory)
+    {
+        $this->collectionFactory = $collectionFactory;
+    }
+
+    /**
+     * @return array
+     */
+    public function toOptionArray(): array
+    {
+        $collection = $this->collectionFactory
+            ->create()
+            ->setEntityTypeFilter(CustomerMetadataInterface::ATTRIBUTE_SET_ID_CUSTOMER)
+            ->addOrder('frontend_label', 'ASC');
+
+        $result = [
+            [
+                'value' => '',
+                'label' => __('Select CPF attribute')
+            ]
+        ];
+
+        foreach ($collection as $item) {
+            $result[] = [
+                'value' => $item->getAttributeCode(),
+                'label' => $item->getFrontendLabel()
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/Model/Config/Source/CustomerAttribute.php
+++ b/Model/Config/Source/CustomerAttribute.php
@@ -14,8 +14,6 @@ use Magento\Framework\Data\OptionSourceInterface;
 
 class CustomerAttribute implements OptionSourceInterface
 {
-    const CUSTOMER_EAV_ENTITY_TYPE_ID = 1;
-
     /**
      * @var CollectionFactory
      */

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -20,7 +20,7 @@
             <group id="attributes" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Attributes</label>
                 <field id="federal_tax_payer_id" translate="label comment" type="select" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <source_model>Intelipost\Quote\Model\Config\Source\Attribute</source_model>
+                    <source_model>Intelipost\Push\Model\Config\Source\CustomerAttribute</source_model>
                     <label>Federal tax payer id</label>
                     <comment>Select CPF attribute</comment>
                 </field>


### PR DESCRIPTION
Referente a issue #8.

Ajusta o select de atributo do Customer na configuração: "Intelipost > Push > Attributes > Federal tax payer id".

Basicamente cria um novo Source Model e modifica o system.xml para utilizar ele ao invés de utilizar o Source Model presente no módulo Intelipost_Quote que basicamente só lista os atributos de Produto.